### PR TITLE
Fix typos in startproject.sh

### DIFF
--- a/startproject
+++ b/startproject
@@ -147,8 +147,8 @@ case ${TMPL} in
     django_drf_celery)
         printf -v MSG_FINISH "\n%s\n  * Django REST Framework\n  * Celery\n" "${MSG_FINISH}"
         ;;
-    django_def)
-        printf -v MSG_FINISH "\n%s\n  * Django REST Framwwork" "${MSG_FINISH}"
+    django_drf)
+        printf -v MSG_FINISH "\n%s\n  * Django REST Framework" "${MSG_FINISH}"
         ;;
     django_celery)
         printf -v MSG_FINISH "\n%s\n  * Celery" "${MSG_FINISH}"


### PR DESCRIPTION
Since the most likely #2 will not be merged, here is the fix typos in `startproject.sh` as a separate PR.