### PR TITLE
Add `packaging` install step in How to use

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ pyenv virtualenv 3.7.5 my_project
 pyenv activate my_project
 ```
 
-Install cookiecutter:
+Install cookiecutter and packaging:
 
 ```bash
-pip install cookiecutter
+pip install cookiecutter packaging
 ```
 
 Step into directory you want to create project and generate project with cookiecutter:


### PR DESCRIPTION
Seems like our `hooks/post_gen_project.py` relies on PYPA [packaging](https://pypi.org/project/packaging/)
And cookiecutter alone does not supply it. Let's add it to the doc
