### PR TITLE
Increase max_length and removed null=True arguments in UserAccount model

### DIFF
--- a/{{ cookiecutter.project_slug }}/api/{{ cookiecutter.project_slug }}/apps/accounts/migrations/0001_initial.py
+++ b/{{ cookiecutter.project_slug }}/api/{{ cookiecutter.project_slug }}/apps/accounts/migrations/0001_initial.py
@@ -30,9 +30,9 @@ class Migration(migrations.Migration):
                 ("uuid", models.UUIDField(default=uuid.uuid4, editable=False, primary_key=True, serialize=False)),
                 ("created", models.DateTimeField(auto_now_add=True, db_index=True, verbose_name="created")),
                 ("updated", models.DateTimeField(auto_now=True, verbose_name="updated")),
-                ("email", models.EmailField(max_length=128, unique=True, verbose_name="Email")),
-                ("first_name", models.CharField(blank=True, max_length=30, null=True, verbose_name="first name")),
-                ("last_name", models.CharField(blank=True, max_length=30, null=True, verbose_name="last name")),
+                ("email", models.EmailField(max_length=254, unique=True, verbose_name="email address")),
+                ("first_name", models.CharField(blank=True, max_length=150, verbose_name="first name")),
+                ("last_name", models.CharField(blank=True, max_length=150, verbose_name="last name")),
                 (
                     "is_staff",
                     models.BooleanField(

--- a/{{ cookiecutter.project_slug }}/api/{{ cookiecutter.project_slug }}/apps/accounts/models/user_account.py
+++ b/{{ cookiecutter.project_slug }}/api/{{ cookiecutter.project_slug }}/apps/accounts/models/user_account.py
@@ -29,9 +29,9 @@ class UserManager(core_models.CoreManager, BaseUserManager):
 
 class UserAccount(PermissionsMixin, CoreModel, AbstractBaseUser):
 
-    email = models.EmailField(verbose_name=gettext_lazy("Email"), max_length=128, unique=True)
-    first_name = models.CharField(verbose_name=gettext_lazy("first name"), max_length=30, blank=True, null=True)
-    last_name = models.CharField(verbose_name=gettext_lazy("last name"), max_length=30, blank=True, null=True)
+    email = models.EmailField(verbose_name=gettext_lazy("email address"), unique=True)
+    first_name = models.CharField(verbose_name=gettext_lazy("first name"), max_length=150, blank=True)
+    last_name = models.CharField(verbose_name=gettext_lazy("last name"), max_length=150, blank=True)
     is_staff = models.BooleanField(
         gettext_lazy("staff status"),
         default=False,

--- a/{{ cookiecutter.project_slug }}/api/{{ cookiecutter.project_slug }}/apps/accounts/tests/test_models/test_user_model.py
+++ b/{{ cookiecutter.project_slug }}/api/{{ cookiecutter.project_slug }}/apps/accounts/tests/test_models/test_user_model.py
@@ -137,9 +137,9 @@ def test_get_short_name(user_account, email):
     "first_name,last_name,email,expected",
     [
         ("Jane", "Doe", "jane@example.com", "Jane Doe <jane@example.com>"),
-        (None, None, "jane@example.com", "jane@example.com"),
-        (None, "Doe", "jane@example.com", "jane@example.com"),
-        ("Jane", None, "jane@example.com", "jane@example.com"),
+        ("", "", "jane@example.com", "jane@example.com"),
+        ("", "Doe", "jane@example.com", "jane@example.com"),
+        ("Jane", "", "jane@example.com", "jane@example.com"),
     ],
 )
 @pytest.mark.django_db
@@ -153,7 +153,7 @@ def test_get_full_name(user_account, first_name, last_name, email, expected):
     assert user.get_full_name() == expected
 
 
-@pytest.mark.parametrize("first_name,last_name,expected", [("Jane", "Doe", "Jane Doe"), (None, None, "Dear client")])
+@pytest.mark.parametrize("first_name,last_name,expected", [("Jane", "Doe", "Jane Doe"), ("", "", "Dear client")])
 @pytest.mark.django_db
 def test_notification_salutation(user_account, first_name, last_name, expected):
     user = user_account(first_name=first_name, last_name=last_name)


### PR DESCRIPTION
Increased max_length values for email, first_name and last_name fields in UserAccount model to follow Django`s native AbstractUser model. Removed null=True arguments for string-based fields to avoid two non-data values.