### PR TITLE
Added -allow-unsafe flag to pip_compile in pip_tools.py

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -61,7 +61,7 @@ jobs:
           python3 -m venv build/.env
           source build/.env/bin/activate
           cd build/awesome
-          pip install -U pip
+          pip install pip~=21.3 # TODO: Unpin version when pip-tools gets support >=22.0 (pip install -U pip)
           pip install fabric invoke pip-tools
           fab pip.compile
           fab pip.sync

--- a/{{ cookiecutter.project_slug }}/fabric_scripts/pip_tools.py
+++ b/{{ cookiecutter.project_slug }}/fabric_scripts/pip_tools.py
@@ -7,8 +7,14 @@ from ._common import project_path
 @task()
 def pip_compile(ctx):
     with ctx.cd(project_path("api")):
-        command_build = "pip-compile --upgrade --generate-hashes -o ./requirements-build.txt ./requirements-build.in"
-        command_dev = "pip-compile --upgrade --generate-hashes -o ./requirements-dev.txt ./requirements-dev.in"
+        # TODO: Remove "-allow-unsafe" flag in future versions of pip-tools (when will be enabled by default)
+        #   https://github.com/jazzband/pip-tools/#deprecations
+        command_build = (
+            "pip-compile --upgrade --allow-unsafe --generate-hashes -o ./requirements-build.txt ./requirements-build.in"
+        )
+        command_dev = (
+            "pip-compile --upgrade --allow-unsafe --generate-hashes -o ./requirements-dev.txt ./requirements-dev.in"
+        )
         ctx.run(command_build, pty=True, replace_env=False)
         ctx.run(command_dev, pty=True, replace_env=False)
 


### PR DESCRIPTION
Without flag command "fab pip.sync" falling with error
"setuptools" version is not fixed.
https://github.com/jazzband/pip-tools/#deprecations

In future versions, the --allow-unsafe behavior will be enabled by default. Use --no-allow-unsafe to keep the old behavior. It is recommended to pass the --allow-unsafe now to adapt to the upcoming change.