### PR TITLE
Add in_app_include settings option in sentry configuration

### DIFF
--- a/{{ cookiecutter.project_slug }}/api/{{ cookiecutter.project_slug }}/settings/contrib/sentry.py
+++ b/{{ cookiecutter.project_slug }}/api/{{ cookiecutter.project_slug }}/settings/contrib/sentry.py
@@ -8,6 +8,7 @@ from ..environment import env
 USE_SENTRY = env.bool("{{ cookiecutter.env_prefix }}USE_SENTRY", default=True)
 if USE_SENTRY:  # pragma: no cover
     sentry_kwargs = {
+        "in_app_include": ["{{ cookiecutter.project_slug }}"],
         "dsn": env.str("{{ cookiecutter.env_prefix }}SENTRY_DSN"),
         "environment": env.str("{{ cookiecutter.env_prefix }}SENTRY_ENVIRONMENT"),
         "integrations": [DjangoIntegration()],


### PR DESCRIPTION
This option allows properly filter application traceback in Sentry interface