### PR TITLE
Update `docker-compose.yml` to use hyphen in all resources names instead of underscore

### DIFF
--- a/{{ cookiecutter.project_slug }}/docker/docker-compose.yml
+++ b/{{ cookiecutter.project_slug }}/docker/docker-compose.yml
@@ -1,4 +1,4 @@
-name: '{{ cookiecutter.project_slug }}'
+name: "{{ cookiecutter.project_slug|replace('_', '-') }}"
 
 # Configurations shared between api service, celery and celery beat.
 x-base-api: &base-api
@@ -42,11 +42,11 @@ services:
       POSTGRES_PASSWORD: {{ cookiecutter.__db_password }}
     image: postgres:{{ cookiecutter.postgresql_version }}-alpine
     volumes:
-      - pg_data:/var/lib/postgresql/data:rw
+      - pg-data:/var/lib/postgresql/data:rw
   redis-db:
     image: redis:{{ cookiecutter.redis_version }}-alpine
     volumes:
-      - redis_data:/data:rw
+      - redis-data:/data:rw
   mailpit:
     image: axllent/mailpit:latest
     ports:
@@ -60,7 +60,7 @@ services:
       MINIO_ACCESS_KEY: {{ cookiecutter.__minio_access_key }}
       MINIO_SECRET_KEY: {{ cookiecutter.__minio_secret_key }}
     volumes:
-     - minio_data:/data
+     - minio-data:/data
     command: [ "server", "--console-address", ":9001", "/data" ]
   createbuckets:
     image: minio/mc
@@ -74,6 +74,6 @@ services:
      exit 0;
      "
 volumes:
-  pg_data: {}
-  redis_data: {}
-  minio_data: {}
+  pg-data: {}
+  redis-data: {}
+  minio-data: {}


### PR DESCRIPTION
I noticed that if `project_slug` containt underscores, then names of docker resources is not consistend because containter names use hyphen as separator (e.g. ds_skeleton_sandbox-celery-beat), so I decied to improve that.

### Change list
- Update `name` by replacing `_` with `-` so that the prefix for resources names uses a hyphen;
- Update volumes names to use hyphen.

Unfortunately due to backward incompatibility reasons in https://github.com/compose-spec/compose-go/pull/294 networks and volumes still will have underscore between "name" prefix and resource name itself (e.g. ds-skeleton-sandbox_pg-data). But I think names are more consistent this way anyway.