### PR TITLE
[DI-2709] Adds CI worflow for the generated project

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,9 @@ Run application:
 ```bash
 make compose-up
 ```
+
+We are using docker for running the app, so you don't have to keep your python env locally. 
+But we also use pre-commit hooks, and the `safety` hook requires `poetry` to be in your `PATH`.
+
+> [!TIP]
+> Ensure the poetry installed with the same python version as in `pyproject.toml`

--- a/{{ cookiecutter.project_slug }}/.github/workflows/ci.yml
+++ b/{{ cookiecutter.project_slug }}/.github/workflows/ci.yml
@@ -1,0 +1,53 @@
+name: CI
+on: [push]
+
+concurrency:
+  group: ${{ '{{' }} github.workflow {{ '}}' }}-${{ '{{' }} github.ref {{ '}}' }}
+  cancel-in-progress: true
+
+
+jobs:
+  linter:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code Repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "{{ cookiecutter.python_version.lower() }}"
+
+      # We need `poetry` to run safety pre-commit hook
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+
+      - name: Run pre-commit
+        uses: pre-commit/action@v3.0.1
+
+  # Tests & migrations checks
+  checks:
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Checkout Code Repository
+        uses: actions/checkout@v4
+
+      - name: Create .env file
+        run: |
+          cp ./api/.env.example ./api/.env
+
+      - name: Build the Stack
+        run: make compose-build
+
+      - name: Check missing DB migrations
+        run: make api-check-migrations
+
+      - name: Run DB Migrations
+        run: make api-migrate
+
+      - name: Run `api` Tests
+        run: make api-test
+
+      - name: Tear down the Stack
+        run: make compose-down

--- a/{{ cookiecutter.project_slug }}/.pre-commit-config.yaml
+++ b/{{ cookiecutter.project_slug }}/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ default_language_version:
 repos:
   # General
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v5.0.0
     hooks:
       - id: check-added-large-files
         args: ['--maxkb=10000']
@@ -19,29 +19,22 @@ repos:
       - id: pretty-format-json
         args: ['--autofix', '--indent 2', ]
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.2.4
+    rev: v2.3.0
     hooks:
       - id: codespell
+        args: [ "--toml=api/pyproject.toml" ]
+        additional_dependencies:
+          - tomli
 
   # API
-  - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.265
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.6.9
     hooks:
       - id: ruff
-        args: ['--fix', '--exit-non-zero-on-fix']
+        args: [ '--fix', '--exit-non-zero-on-fix' ]
+      - id: ruff-format
   - repo: https://github.com/Lucas-C/pre-commit-hooks-safety
-    rev: v1.3.1
+    rev: v1.3.3
     hooks:
       - id: python-safety-dependencies-check
-        entry: safety
-        args: [check]
-        files: ./api/requirements-build.txt
-# TODO: Run this hook from docker container.
-#  - repo: local
-#    hooks:
-#      - id: migrations-check
-#        language: system
-#        name: Check for uncreated migrations.
-#        entry: sh -c "make api-check-migrations"
-#        files: models/*.*\.py$
-#        stages: [commit]
+        files: pyproject.toml

--- a/{{ cookiecutter.project_slug }}/Makefile
+++ b/{{ cookiecutter.project_slug }}/Makefile
@@ -26,3 +26,6 @@ compose-down:
 
 compose-build:
 	cd docker/ && docker compose build
+
+api-migrate:
+	cd docker/ && docker compose run --rm api make migrate

--- a/{{ cookiecutter.project_slug }}/Makefile
+++ b/{{ cookiecutter.project_slug }}/Makefile
@@ -9,6 +9,9 @@ api-test:
 api-check-migrations:
 	cd docker/ && docker compose run --rm api make check-migrations
 
+api-migrate:
+	cd docker/ && docker compose run --rm api make migrate
+
 api-check:
 	cd docker/ && docker compose run --rm api make check
 
@@ -26,6 +29,3 @@ compose-down:
 
 compose-build:
 	cd docker/ && docker compose build
-
-api-migrate:
-	cd docker/ && docker compose run --rm api make migrate

--- a/{{ cookiecutter.project_slug }}/README.md
+++ b/{{ cookiecutter.project_slug }}/README.md
@@ -56,3 +56,7 @@ minimal setup.
 If you need python environment, to run some commands, just use `make api-bash`, and you will be in the container with
 all dependencies installed.
 
+> [!NOTE]  
+> To ensure your code follow the standards etc. we strongly recommend to use `pre-commit` locally, that means you need 
+> to have it installed manually, see [pre-commit hook docs](docs/pre_commit_hook.md) for more details.
+

--- a/{{ cookiecutter.project_slug }}/api/pyproject.toml
+++ b/{{ cookiecutter.project_slug }}/api/pyproject.toml
@@ -125,3 +125,6 @@ exclude_lines =[
 ]
 show_missing = true
 
+[tool.codespell]
+skip = "*.lock"
+ignore-words = "codespell-ignore-words.txt"

--- a/{{ cookiecutter.project_slug }}/docs/pre_commit_hook.md
+++ b/{{ cookiecutter.project_slug }}/docs/pre_commit_hook.md
@@ -2,11 +2,18 @@
 
 To run additional checks before making commit we use [Pre-commit](https://pre-commit.com/) hooks.
 
-`pre-commit` package is installed with backend requirements, so there is no need of [manual installation](https://pre-commit.com/#install).
-But you need to generate the actual git pre-commit hook. It should be done only once:
+
+Since the `api` is running inside docker container we don't have a pre-commit as a dependency there, so you need to 
+install `pre-commit` package [manually](https://pre-commit.com/#install).
+
+> [!NOTE]  
+> The `safety` hook also requires `poetry` to be in your `PATH`.
+> Ensure the poetry installed with the same python version as in `pyproject.toml`
+
+You need to generate the actual git pre-commit hook. It should be done only once:
 
 ```bash
-pre-commit install
+pre-commit install --install-hooks
 ```
 
 To run pre-commit hooks manually:

--- a/{{ cookiecutter.project_slug }}/docs/pre_commit_hook.md
+++ b/{{ cookiecutter.project_slug }}/docs/pre_commit_hook.md
@@ -3,8 +3,8 @@
 To run additional checks before making commit we use [Pre-commit](https://pre-commit.com/) hooks.
 
 
-Since the `api` is running inside docker container we don't have a pre-commit as a dependency there, so you need to 
-install `pre-commit` package [manually](https://pre-commit.com/#install).
+Since the `api` is running inside docker container and we don't have a pre-commit as a dependency there, you need to 
+install `pre-commit` package [locally](https://pre-commit.com/#install).
 
 > [!NOTE]  
 > The `safety` hook also [requires](https://github.com/Lucas-C/pre-commit-hooks-safety?tab=readme-ov-file#supported-files) `poetry` to be in your `PATH`.

--- a/{{ cookiecutter.project_slug }}/docs/pre_commit_hook.md
+++ b/{{ cookiecutter.project_slug }}/docs/pre_commit_hook.md
@@ -7,8 +7,8 @@ Since the `api` is running inside docker container we don't have a pre-commit as
 install `pre-commit` package [manually](https://pre-commit.com/#install).
 
 > [!NOTE]  
-> The `safety` hook also requires `poetry` to be in your `PATH`.
-> Ensure the poetry installed with the same python version as in `pyproject.toml`
+> The `safety` hook also [requires](https://github.com/Lucas-C/pre-commit-hooks-safety?tab=readme-ov-file#supported-files) `poetry` to be in your `PATH`.
+> Ensure the poetry [installed](https://python-poetry.org/docs/#installation) with the same python version as in `pyproject.toml`
 
 You need to generate the actual git pre-commit hook. It should be done only once:
 


### PR DESCRIPTION
### Change list

- Adds `.guthub/workflows/ci.yml` with couple jobs to:
    - run pre-commit hooks on CI, inc. ruff linting & formatting;
    - run `api` tests;
- Update a couple of versions for pre-commit hooks
- Update outdated `safety` pre-commit hook to work with `poetry`

### The workflow tested on the newly generated project, and looks like this on GH:
<img width="756" alt="image" src="https://github.com/user-attachments/assets/9b622d3c-c562-4f07-a7ef-be536bb71f7e">
<img width="1709" alt="image" src="https://github.com/user-attachments/assets/ec33db17-0829-4c92-bf2f-32623ca41a36">
<img width="1703" alt="image" src="https://github.com/user-attachments/assets/e0c0dc5b-5e68-4754-b906-7f4e02cccc05">
<img width="1703" alt="image" src="https://github.com/user-attachments/assets/39c31162-fb53-4ec1-8b5e-6477791fafa9">


