### PR TITLE
feat: replace MinIO with RustFS for S3-compatible object storage

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -10,7 +10,7 @@
     "__db_name": "{{ cookiecutter.project_slug | lower() }}_db",
     "__db_user": "{{ cookiecutter.project_slug | lower() }}_user",
     "__db_password": "{{ cookiecutter.project_slug | lower() }}_password",
-    "__minio_access_key": "minioadminuser",
-    "__minio_secret_key": "minioadminpassword",
-    "__minio_bucket_name": "storage"
+    "__rustfs_access_key": "rustfsadmin",
+    "__rustfs_secret_key": "rustfsadmin",
+    "__rustfs_bucket_name": "storage"
 }

--- a/{{ cookiecutter.project_slug }}/api/.env.example
+++ b/{{ cookiecutter.project_slug }}/api/.env.example
@@ -14,14 +14,14 @@
 
 {{ cookiecutter.__env_prefix }}DJANGO_ADMIN_URL=admin/
 
-# Minio credentials
-AWS_S3_ACCESS_KEY_ID={{ cookiecutter.__minio_access_key }}
-AWS_S3_SECRET_ACCESS_KEY={{ cookiecutter.__minio_secret_key }}
+# RustFS credentials
+AWS_S3_ACCESS_KEY_ID={{ cookiecutter.__rustfs_access_key }}
+AWS_S3_SECRET_ACCESS_KEY={{ cookiecutter.__rustfs_secret_key }}
 
 # Files storage settings
-{{ cookiecutter.__env_prefix }}DEFAULT_FILE_STORAGE_BUCKET_NAME={{ cookiecutter.__minio_bucket_name }}
-{{ cookiecutter.__env_prefix }}DEFAULT_FILE_STORAGE_ENDPOINT_URL=http://minio:9000/
-{{ cookiecutter.__env_prefix }}DEFAULT_FILE_STORAGE_CUSTOM_DOMAIN=127.0.0.1:9000/{{ cookiecutter.__minio_bucket_name }}
+{{ cookiecutter.__env_prefix }}DEFAULT_FILE_STORAGE_BUCKET_NAME={{ cookiecutter.__rustfs_bucket_name }}
+{{ cookiecutter.__env_prefix }}DEFAULT_FILE_STORAGE_ENDPOINT_URL=http://rustfs:9000/
+{{ cookiecutter.__env_prefix }}DEFAULT_FILE_STORAGE_CUSTOM_DOMAIN=127.0.0.1:9000/{{ cookiecutter.__rustfs_bucket_name }}
 {{ cookiecutter.__env_prefix }}DEFAULT_FILE_STORAGE_URL_PROTOCOL=http:
 
 {{ cookiecutter.__env_prefix }}USE_SENTRY=off

--- a/{{ cookiecutter.project_slug }}/docker/compose.yml
+++ b/{{ cookiecutter.project_slug }}/docker/compose.yml
@@ -19,7 +19,7 @@ services:
       - postgres-db
       - redis-db
       - mailpit
-      - minio
+      - rustfs
       - createbuckets
     ports:
       - ${LOCAL_IP:-127.0.0.1}:${API_LOCAL_PORT:-8000}:8000
@@ -51,29 +51,30 @@ services:
     image: axllent/mailpit:latest
     ports:
      - ${LOCAL_IP:-127.0.0.1}:${MAILPIT_LOCAL_PORT:-8025}:8025
-  minio:
-    image: minio/minio:latest
+  rustfs:
+    image: rustfs/rustfs:latest
     ports:
-     - ${LOCAL_IP:-127.0.0.1}:${MINIO_LOCAL_PORT:-9000}:9000
-     - ${LOCAL_IP:-127.0.0.1}:${MINIO_CONSOLE_LOCAL_PORT:-9001}:9001
+     - ${LOCAL_IP:-127.0.0.1}:${RUSTFS_LOCAL_PORT:-9000}:9000
+     - ${LOCAL_IP:-127.0.0.1}:${RUSTFS_CONSOLE_LOCAL_PORT:-9001}:9001
     environment:
-      MINIO_ROOT_USER: {{ cookiecutter.__minio_access_key }}
-      MINIO_ROOT_PASSWORD: {{ cookiecutter.__minio_secret_key }}
+      RUSTFS_ACCESS_KEY: {{ cookiecutter.__rustfs_access_key }}
+      RUSTFS_SECRET_KEY: {{ cookiecutter.__rustfs_secret_key }}
     volumes:
-     - minio-data:/data
-    command: [ "server", "--console-address", ":9001", "/data" ]
+     - rustfs-data:/data
+  # RustFS officially supports MinIO Client (mc) for bucket management
+  # See: https://docs.rustfs.com/developer/mc.html
   createbuckets:
     image: minio/mc
     depends_on:
-      - minio
+      - rustfs
     entrypoint: >
      /bin/sh -c "
-     until (/usr/bin/mc alias set myminio http://minio:9000 {{ cookiecutter.__minio_access_key }} {{ cookiecutter.__minio_secret_key }}) do echo '...waiting...' && sleep 1; done;
-     /usr/bin/mc mb --ignore-existing myminio/{{ cookiecutter.__minio_bucket_name }};
-     /usr/bin/mc anonymous set download myminio/{{ cookiecutter.__minio_bucket_name }};
+     until (/usr/bin/mc alias set myrustfs http://rustfs:9000 {{ cookiecutter.__rustfs_access_key }} {{ cookiecutter.__rustfs_secret_key }}) do echo '...waiting...' && sleep 1; done;
+     /usr/bin/mc mb --ignore-existing myrustfs/{{ cookiecutter.__rustfs_bucket_name }};
+     /usr/bin/mc anonymous set download myrustfs/{{ cookiecutter.__rustfs_bucket_name }};
      exit 0;
      "
 volumes:
   pg-data: {}
   redis-data: {}
-  minio-data: {}
+  rustfs-data: {}

--- a/{{ cookiecutter.project_slug }}/docs/docker.md
+++ b/{{ cookiecutter.project_slug }}/docs/docker.md
@@ -1,9 +1,9 @@
-## Docker 
+## Docker
 
-To start project faster we use docker and docker compose. In docker compose file we have all services that we need to 
+To start project faster we use docker and docker compose. In docker compose file we have all services that we need to
 run, some of them mapped to local ports, so we can access them from the host machine.
-You can change default ports by create `.env` file in `docker` directory and set variables with the same name as in 
-`docker-compose.yml` file. 
+You can change default ports by create `.env` file in `docker` directory and set variables with the same name as in
+`docker-compose.yml` file.
 
 Example of `.env` file:
 
@@ -15,7 +15,7 @@ API_LOCAL_PORT=8099 # change default port for api service from 8000 to 8099
 
 ### api
 
-The `api` service is responsible for running django application. 
+The `api` service is responsible for running django application.
 The api service has the following configurations:
 
  - Command: `make run` (runs the API, see `api/Makefile` for details)
@@ -25,14 +25,14 @@ The api service has the following configurations:
 sure that we have the same code in the container and on the host machine for development purposes.)
 
 #### api build
- - Target `local` is used to build image for local development, check `docker/images/api/Dockerfile` for details. 
+ - Target `local` is used to build image for local development, check `docker/images/api/Dockerfile` for details.
  - Target `live` is used to build image for production. `docker/images/api/Dockerfile` - is production ready, but docker
    compose configuration only for local development.
 
-   
+
 ### celery-worker
 
-The `celery-worker` service is responsible for running the Celery worker. It uses same image as `api` service, 
+The `celery-worker` service is responsible for running the Celery worker. It uses same image as `api` service,
 but instead of starting web server, it starts celery worker.
 
  - Command: `make celery-worker-run` (check `api/Makefile` for details)
@@ -59,20 +59,32 @@ The `mailpit` service is an instance of the Mailpit email testing tool. It has t
 
 - Ports: `${LOCAL_IP:-127.0.0.1}:${MAILPIT_LOCAL_PORT:-8025}:8025` (by default maps http://localhost:8025 to the Mailpit container)
 
-### minio
+### rustfs
 
-The `minio` service is an instance of the Minio - S3 compatible object store. We store static and media files there.
+The `rustfs` service is an instance of [RustFS](https://rustfs.com/) - a high-performance, S3-compatible object storage
+system built in Rust. We store static and media files there. RustFS is a drop-in replacement for MinIO with better
+performance and Apache 2.0 license.
+
 It has the following configurations:
-- Ports: 
-  - `${LOCAL_IP:-127.0.0.1}:${MINIO_LOCAL_PORT:-9000}:9000` (maps MinIO to the local IP and port)
-  - `${LOCAL_IP:-127.0.0.1}:${MINIO_CONSOLE_LOCAL_PORT:-9001}:9001` (maps MinIO Console UI to the local IP and port)
-- Environment variables: credentials for Minio.
+- Ports:
+  - `${LOCAL_IP:-127.0.0.1}:${RUSTFS_LOCAL_PORT:-9000}:9000` (maps RustFS API to the local IP and port)
+  - `${LOCAL_IP:-127.0.0.1}:${RUSTFS_CONSOLE_LOCAL_PORT:-9001}:9001` (maps RustFS Console UI to the local IP and port)
+- Environment variables: `RUSTFS_ACCESS_KEY` and `RUSTFS_SECRET_KEY` for authentication.
+- Default credentials: `rustfsadmin` / `rustfsadmin`
 
-MinIO runs Console (UI) on random port by default, we set it to `9001` to make it stable and map to the same local port.
+RustFS Console (UI) is available at http://localhost:9001 by default.
 
 ### createbuckets
-Service execute some [mc command](https://min.io/docs/minio/linux/reference/minio-mc.html) to create bucket in Minio to 
-upload `api` static and media files.
+
+This service creates default buckets in RustFS for storing static and media files using
+[MinIO Client (mc)](https://min.io/docs/minio/linux/reference/minio-mc.html). RustFS officially supports mc -
+see [RustFS mc documentation](https://docs.rustfs.com/developer/mc.html).
+
+The service:
+1. Waits for RustFS to be available
+2. Creates an alias `myrustfs` pointing to the RustFS instance
+3. Creates a bucket for storing files
+4. Sets anonymous download policy on the bucket
 
 
 
@@ -81,7 +93,7 @@ We didn't add these services by default, do not overload compose file.
 
 #### pgadmin
 The `pgadmin` service is an instance of the pgAdmin - PostgreSQL database management tool with nice UI that allow you to
-check database, tables, run queries, etc. 
+check database, tables, run queries, etc.
 
 ```yaml
 services:
@@ -100,10 +112,9 @@ volumes:
 
 #### redisinsight
 
-The `redisinsight` service is an instance of the RedisInsight - the Redis GUI, super useful to debug Redis. 
+The `redisinsight` service is an instance of the RedisInsight - the Redis GUI, super useful to debug Redis.
 
 ```yaml
-version: "3.8"
 services:
   redisinsight:
     image: redislabs/redisinsight:latest
@@ -117,10 +128,9 @@ volumes:
 
 #### flower
 
-The `flower` service is an instance of the Flower - the Celery monitoring tool. 
+The `flower` service is an instance of the Flower - the Celery monitoring tool.
 
 ```yaml
-version: "3.9"
 services:
   flower:
     image: mher/flower:0.9.7

--- a/{{ cookiecutter.project_slug }}/docs/docker.md
+++ b/{{ cookiecutter.project_slug }}/docs/docker.md
@@ -72,7 +72,7 @@ It has the following configurations:
 - Environment variables: `RUSTFS_ACCESS_KEY` and `RUSTFS_SECRET_KEY` for authentication.
 - Default credentials: `rustfsadmin` / `rustfsadmin`
 
-RustFS Console (UI) is available at http://localhost:9001 by default.
+RustFS Console (UI) is available at http://localhost:9001 by default. 
 
 ### createbuckets
 


### PR DESCRIPTION
- Replace minio service with rustfs in docker compose
- Update environment variables: MINIO_ROOT_USER/PASSWORD → RUSTFS_ACCESS_KEY/SECRET_KEY
- Update cookiecutter variables: __minio_* → __rustfs_*
- Update default credentials to rustfsadmin/rustfsadmin
- Update .env.example with rustfs endpoint
- Update docker.md documentation with RustFS details
- Add comment about official mc support in RustFS

RustFS is a high-performance, S3-compatible object storage built in Rust with Apache 2.0 license. It officially supports MinIO Client (mc) for bucket management: https://docs.rustfs.com/developer/mc.html